### PR TITLE
bugfix: remove references to deprecated mergeTemplate

### DIFF
--- a/velocity-tools-view/src/main/java/org/apache/velocity/tools/view/VelocityLayoutServlet.java
+++ b/velocity-tools-view/src/main/java/org/apache/velocity/tools/view/VelocityLayoutServlet.java
@@ -196,9 +196,11 @@ public class VelocityLayoutServlet extends VelocityViewServlet
      * render for handling layouts
      * @param template {@link Template} object
      * @param context Velocity context
+     * @param request servlet request
      * @param response servlet response
+     * @throws IOException
      */
-    protected void mergeTemplate(Template template, Context context,
+    protected void mergeTemplate(Template template, Context context, HttpServletRequest request,
                                  HttpServletResponse response)
         throws IOException
     {
@@ -248,7 +250,7 @@ public class VelocityLayoutServlet extends VelocityViewServlet
         }
 
         // Render the layout template into the response
-        super.mergeTemplate(template, context, response);
+        super.mergeTemplate(template, context, request, response);
     }
 
 
@@ -288,7 +290,7 @@ public class VelocityLayoutServlet extends VelocityViewServlet
 
             // retrieve and render the error template
             Template et = getTemplate(errorTemplate);
-            mergeTemplate(et, ctx, response);
+            mergeTemplate(et, ctx, request, response);
 
         }
         catch (Exception e2)


### PR DESCRIPTION
I was trying to migrate to 3.x and noticed that VelocityLayoutServlet wasn't working at all because it overwrote the deprecated version of mergeTemplate, which is no longer called by VelocityViewServlet when processing requests. As a result, VelocityLayoutServlet did not render pages using the expected layout templates.

I adjusted VelocityLayoutServlet to use the new method, restoring expected behavior, and now pages use the expected layout templates again.